### PR TITLE
more robust screenshots

### DIFF
--- a/.local/bin/screenshot
+++ b/.local/bin/screenshot
@@ -8,6 +8,10 @@
 
 
 #below works with wayland
-grim ~/pix/screenshots/$(date '+%Y%m%d-%H%M%S.png')
+
+timestampfile=$(date '+%Y%m%d-%H%M%S.png')
+timestampfilepath="$HOME/pix/screenshots/$timestampfile"
+
+grim -g "$(slurp -o)" "$timestampfilepath" && wl-copy < "$timestampfilepath"
 notify-send "screenshot saved"
 


### PR DESCRIPTION
can now just select one monitor, or drag to select region. both will be saved in normal screenshot folder with timestamp and copied to clipboard for easy sharing 